### PR TITLE
fix (algorithm): allow any kid in JWT header to pass validation

### DIFF
--- a/src/crypto/algorithm.rs
+++ b/src/crypto/algorithm.rs
@@ -379,7 +379,7 @@ impl Algorithm {
         // We need an Option(&str) instead of Option(String)
         let kid_matches = match &self.kid {
             Some(string) => kid == Some(string.as_ref()),
-            None => kid == None,
+            None => true,
         };
         if !kid_matches {
             return Err(Error::MalformedToken(ErrorDetails::new(format!(


### PR DESCRIPTION
Hi!

The idea of the PR is to allow any `kid` in header. The reason is that `kid` is an alias for a public key used in verification. If we have a set of keys or key is changed, `kid` indicates the specific one. So, we want to consider any `kid` in header as valid.

May be the solution provided is not best one, the other possible solution is to explicitly set any kid in Algorithm or Validator.
